### PR TITLE
new views, previous - deprecated

### DIFF
--- a/keymaps/minifier.cson
+++ b/keymaps/minifier.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace .editor':
+'atom-text-editor atom-workspace':
   'option-shift-m': 'minifier:minify'
   'alt-shift-m': 'minifier:minify'


### PR DESCRIPTION
Because Atom 0.186.0 says that old view selectors is deprecated :wrench: